### PR TITLE
Daniel/heavy connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ A simple development stack for HeavyAI using docker compose.  It includes two ke
 > ./configHeavyConnect.sh 
 > docker restart heavyaiserver
 > ``` 
-> To configure Snowflake for a client account edit `/var/lib/heavyai/odbc/odbc.ini` on the host machine, specifically account parameters `SERVER` and `ACCOUNT` 
-5. Launch a browser pointing at port 8001 on the server and you should be prompted to enter your Heavy.AI license.
-6. You can now open up a jupyter envrionment using the icon in Immerse.
-7. On the first launch of jupyter, enter your user name and no value for password.  This will create a jupyter environment for that user.
+> To configure Snowflake for a client account edit `/var/lib/heavyai/odbc/odbc.ini` on the host machine, specifically the parameters `SERVER` and `ACCOUNT` 
+5. Launch a browser pointing at port 8001 on the server, you should be prompted to enter your Heavy.AI license.
+6. You can now open up a jupyter environment using the icon in Immerse.
+7. On the first launch of jupyter, enter your username and no value for password.  This will create a jupyter environment for that user.
 
 ## Ports
 - This config uses a reverse proxy to route all web traffic through port 8001.  So when you connect to Immerse, you connect on port 8001.  This can certainly be changed, but this is the only port that needs to be externally exposed.  To change this port change the `EXTERNAL_PORT` variable in the `install.sh` script.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,15 @@ A simple development stack for HeavyAI using docker compose.  It includes two ke
 3. Run the ```installHeavy.sh``` script.  This will create the necessary config files and docker-compose files to stand up the test environment.  For basic usage, you do not need the ```heavyVersions.json``` file at all.  This is only used to load a custom Heavy.AI package.
 4. Launch the environment using the command:
 `docker-compose up -d`
-
+>Optional: Install and configure HeavyConnect for Snowflake.
+> 
+> Run the following commands from within the `heavyai-devstack` directory.
+> ```
+> docker exec -it heavyaiserver /tmp/install_odbc_drivers.sh  
+> ./configHeavyConnect.sh 
+> docker restart heavyaiserver
+> ``` 
+> To configure Snowflake for a client account edit `/var/lib/heavyai/odbc/odbc.ini` on the host machine, specifically account parameters `SERVER` and `ACCOUNT` 
 5. Launch a browser pointing at port 8001 on the server and you should be prompted to enter your Heavy.AI license.
 6. You can now open up a jupyter envrionment using the icon in Immerse.
 7. On the first launch of jupyter, enter your user name and no value for password.  This will create a jupyter environment for that user.

--- a/configHeavyConnect.sh
+++ b/configHeavyConnect.sh
@@ -33,4 +33,3 @@ PORT=443
 SSL=on
 ACCOUNT=lqa26912
 odbciniEnd
-

--- a/configHeavyConnect.sh
+++ b/configHeavyConnect.sh
@@ -1,4 +1,4 @@
-
+#!/bin/bash
 cat > "/var/lib/heavyai/odbc/odbcinst.ini" <<odbcinstiniEnd
 [ODBC Drivers]
 Snowflake=Installed

--- a/configHeavyConnect.sh
+++ b/configHeavyConnect.sh
@@ -1,0 +1,36 @@
+
+cat > "/var/lib/heavyai/odbc/odbcinst.ini" <<odbcinstiniEnd
+[ODBC Drivers]
+Snowflake=Installed
+Snowflake=Installed
+
+
+[Snowflake]
+APILevel=1
+ConnectFunctions=YYY
+Description=Snowflake DSII
+Driver=/usr/lib/snowflake/odbc/lib/libSnowflake.so
+odbcinstiniEnd
+
+cat > "/var/lib/heavyai/odbc/odbc.ini" <<odbciniEnd
+[ODBC Drivers]
+Snowflake=Installed
+Snowflake=Installed
+
+
+[Snowflake]
+APILevel=1
+ConnectFunctions=YYY
+Description=Snowflake DSII
+Driver=/usr/lib/snowflake/odbc/lib/libSnowflake.so
+
+[snowflake]
+Description=SnowflakeDB
+Driver=Snowflake
+Locale=en-US
+SERVER=lqa26912.snowflakecomputing.com
+PORT=443
+SSL=on
+ACCOUNT=lqa26912
+odbciniEnd
+

--- a/installHeavy.sh
+++ b/installHeavy.sh
@@ -180,6 +180,7 @@ cat >$NGINX_CONF_FILE <<nginxEnd
 events {}
 
 http {
+  client_max_body_size 10000M;
   map \$http_upgrade \$connection_upgrade {
     default upgrade;
     ''      close;

--- a/installHeavy.sh
+++ b/installHeavy.sh
@@ -46,6 +46,8 @@ services:
     ipc: shareable
     volumes:
       - /var/lib/heavyai:/var/lib/heavyai
+      - /var/lib/heavyai/odbc/odbc.ini:/etc/odbc.ini
+      - /var/lib/heavyai/odbc/odbcinst.ini:/etc/odbcinst.ini
     networks:
       - jupyterhub-network
     ports:
@@ -53,6 +55,10 @@ services:
       - "6274:6274"
       - "6276:6276"
       - "6278:6278"
+    command: sh -c "apt-get update && apt-get install -y odbc-postgresql unixodbc
+                    wget -P /tmp https://sfc-repo.snowflakecomputing.com/odbc/linux/3.1.0/snowflake-odbc-3.1.0.x86_64.deb
+                    dpkg -i /tmp/snowflake-odbc-3.1.0.x86_64.deb
+                    rm /tmp/snowflake-odbc-2.25.2.x86_64.deb"
 
   hub:
     build:
@@ -331,6 +337,7 @@ installFiles(){
 
   
   sudo mkdir /var/lib/heavyai
+  sudo mkdir /var/lib/heavyai/odbc
   sudo chown ubuntu /var/lib/heavyai
   sudo mkdir /var/lib/heavyai/import
   sudo mkdir /var/lib/heavyai/jupyter

--- a/installHeavy.sh
+++ b/installHeavy.sh
@@ -44,7 +44,6 @@ services:
     image: $DOCKER_IMAGE
     restart: always
     ipc: shareable
-    entrypoint: ["/tmp/install_odbc_drivers.sh"]
     volumes:
       - /var/lib/heavyai:/var/lib/heavyai
       - /var/lib/heavyai/odbc/odbc.ini:/etc/odbc.ini

--- a/installHeavy.sh
+++ b/installHeavy.sh
@@ -109,7 +109,7 @@ allowed-import-paths = ["/var/lib/heavyai/import"]
 allowed-export-paths = ["/"]
 idle-session-duration = 43200
 enable-logs-system-tables = true
-enable-executor-resource-mgr=0
+enable-executor-resource-mgr= true
 
 [web]
 port = 6273

--- a/installHeavy.sh
+++ b/installHeavy.sh
@@ -84,7 +84,7 @@ services:
       # JupyterHub will spawn this Notebook image for users
       DOCKER_NOTEBOOK_IMAGE: jupyter/base-notebook:latest
       # Notebook directory inside user image
-      DOCKER_NOTEBOOK_DIR: /home/jovyan/work
+      DOCKER_NOTEBOOK_DIR: /home/jovyan/work/jupyterData
       # Using this run command
       DOCKER_SPAWN_CMD: start-singleuser.sh
 
@@ -109,7 +109,7 @@ allowed-import-paths = ["/var/lib/heavyai/import"]
 allowed-export-paths = ["/"]
 idle-session-duration = 43200
 enable-logs-system-tables = true
-enable-executor-resource-mgr= true
+enable-executor-resource-mgr=0
 
 [web]
 port = 6273
@@ -287,17 +287,17 @@ c.DockerSpawner.network_name = os.environ["DOCKER_NETWORK_NAME"]
 # Most jupyter/docker-stacks *-notebook images run the Notebook server as
 # user jovyan, and set the notebook directory to /home/jovyan/work.
 # We follow the same convention.
-notebook_dir = os.environ.get("DOCKER_NOTEBOOK_DIR", "/home/jovyan/work")
+notebook_dir = os.environ.get("DOCKER_NOTEBOOK_DIR")
 c.DockerSpawner.notebook_dir = notebook_dir
 
 # Mount the real user's Docker volume on the host to the notebook user's
 # notebook directory in the container
 c.DockerSpawner.volumes = {"jupyterhub-user-{username}": notebook_dir, 
-                        "jupyterhub-shared": "/home/jovyan/work/shared",
-                        "jupyterhub-data": "/home/jovyan/work/data"}
+                        #"jupyterhub-shared": "/home/jovyan/work/shared",
+                        "/home/ubuntu/jupyterData": "/home/jovyan"}
 
 # Remove containers once they are stopped
-c.DockerSpawner.remove = False
+c.DockerSpawner.remove = True
 
 # For debugging arguments passed to spawned containers
 c.DockerSpawner.debug = True
@@ -309,7 +309,6 @@ c.DockerSpawner.environment = {
 }
 
 ##NETWORKING
-c.DockerSpawner.remove = False
 c.Spawner.default_url = '/lab'
 c.Spawner.args = ['--NotebookApp.allow_origin=*']
 
@@ -334,8 +333,10 @@ installFiles(){
   sudo mkdir /var/lib/heavyai
   sudo chown ubuntu /var/lib/heavyai
   sudo mkdir /var/lib/heavyai/import
-  sudo mkdir /var/lib/heavyai/import/jhub_heavai_dropbox
   sudo mkdir /var/lib/heavyai/jupyter
+  sudo mkdir /home/$USER/jupyterData
+  sudo chmod -R 777 /home/$USER/jupyterData
+  sudo chmod ugo+rwx -R /home/$USER/jupyterData
   sudo chown -R ubuntu /var/lib/heavyai
   sudo cp ./daemon.json /etc/docker/.
   sudo systemctl stop docker

--- a/installHeavy.sh
+++ b/installHeavy.sh
@@ -44,10 +44,12 @@ services:
     image: $DOCKER_IMAGE
     restart: always
     ipc: shareable
+    entrypoint: ["/tmp/install_odbc_drivers.sh"]
     volumes:
       - /var/lib/heavyai:/var/lib/heavyai
       - /var/lib/heavyai/odbc/odbc.ini:/etc/odbc.ini
       - /var/lib/heavyai/odbc/odbcinst.ini:/etc/odbcinst.ini
+      - ./install_odbc_drivers.sh:/tmp/install_odbc_drivers.sh
     networks:
       - jupyterhub-network
     ports:
@@ -55,10 +57,6 @@ services:
       - "6274:6274"
       - "6276:6276"
       - "6278:6278"
-    command: sh -c "apt-get update && apt-get install -y odbc-postgresql unixodbc
-                    wget -P /tmp https://sfc-repo.snowflakecomputing.com/odbc/linux/3.1.0/snowflake-odbc-3.1.0.x86_64.deb
-                    dpkg -i /tmp/snowflake-odbc-3.1.0.x86_64.deb
-                    rm /tmp/snowflake-odbc-2.25.2.x86_64.deb"
 
   hub:
     build:

--- a/install_odbc_drivers.sh
+++ b/install_odbc_drivers.sh
@@ -1,5 +1,6 @@
+#!/bin/bash
 apt-get update && apt-get install -y odbc-postgresql unixodbc
 cd /tmp
 wget https://sfc-repo.snowflakecomputing.com/odbc/linux/3.1.0/snowflake-odbc-3.1.0.x86_64.deb
-yes N | dpkg -i --configure -a snowflake-odbc-3.1.0.x86_64.deb
+yes N | dpkg -i snowflake-odbc-3.1.0.x86_64.deb
 rm ./snowflake-odbc-3.1.0.x86_64.deb

--- a/install_odbc_drivers.sh
+++ b/install_odbc_drivers.sh
@@ -1,0 +1,5 @@
+apt-get update && apt-get install -y odbc-postgresql unixodbc
+cd /tmp
+wget https://sfc-repo.snowflakecomputing.com/odbc/linux/3.1.0/snowflake-odbc-3.1.0.x86_64.deb
+yes N | dpkg -i --configure -a snowflake-odbc-3.1.0.x86_64.deb
+rm ./snowflake-odbc-3.1.0.x86_64.deb

--- a/install_odbc_drivers.sh
+++ b/install_odbc_drivers.sh
@@ -2,5 +2,5 @@
 apt-get update && apt-get install -y odbc-postgresql unixodbc
 cd /tmp
 wget https://sfc-repo.snowflakecomputing.com/odbc/linux/3.1.0/snowflake-odbc-3.1.0.x86_64.deb
-yes N | dpkg -i snowflake-odbc-3.1.0.x86_64.deb
+dpkg -i snowflake-odbc-3.1.0.x86_64.deb
 rm ./snowflake-odbc-3.1.0.x86_64.deb

--- a/nvidiaSetup.sh
+++ b/nvidiaSetup.sh
@@ -17,7 +17,7 @@ install_docker(){
    stable"
    
   sudo apt update
-  sudo apt install docker-ce docker-ce-cli containerd.io
+  sudo apt install docker-ce docker-ce-cli containerd.io docker-compose jq
   sudo usermod  --append --groups docker $USER
   sudo docker run hello-world
   }

--- a/nvidiaSetup.sh
+++ b/nvidiaSetup.sh
@@ -59,7 +59,7 @@ sudo docker run --gpus=all --rm nvidia/cuda:11.8.0-runtime-ubuntu20.04 nvidia-sm
 }
 
 #clean_docker #Very seldom is this step required, but it is included in the standard Heavy.AI documentation
-#install_docker #Most environments already have docker installed and a more straightforward Docker install tends to work.  This step is also outlined in Heavy.AI documentation, but is most often not needed
+install_docker #Most environments already have docker installed and a more straightforward Docker install tends to work.  This step is also outlined in Heavy.AI documentation, but is most often not needed
 simple_docker_config
 install_nvidia_drivers
 nvidia_docker_runtime


### PR DESCRIPTION
Add scripts to install Snowflake and Postgres Drivers and configure HeavyConnect. 

add 3 mapped files to docker-compose heavyaiserver 
```     
- /var/lib/heavyai/odbc/odbc.ini:/etc/odbc.ini
- /var/lib/heavyai/odbc/odbcinst.ini:/etc/odbcinst.ini
- ./install_odbc_drivers.sh:/tmp/install_odbc_drivers.sh
```
add additional command (`sudo mkdir /var/lib/heavyai/odbc`) to installFiles() function in `installHeavy.sh`
add `install_odbc_drivers.sh` to auto install the drivers necessary for Snowflake and Postgres
add  `configHeavyConnect.sh` to populate the odbc.ini and odbcinst.ini files
Update README.md